### PR TITLE
Fix typos in plugin configs

### DIFF
--- a/lua/pwalleni/plugins/lsp/lspsaga.lua
+++ b/lua/pwalleni/plugins/lsp/lspsaga.lua
@@ -3,8 +3,8 @@ local saga = require("lspsaga")
 saga.setup({
 	use_saga_diagnostic_sign = true,
 	error_sign = "",
-	warn_sign = "",
-	hintsign = " ",
-	infor_sign = "",
+    warn_sign = "",
+    hint_sign = " ",
+    infor_sign = "",
 	border_style = "round",
 })

--- a/lua/pwalleni/plugins/lualine.lua
+++ b/lua/pwalleni/plugins/lualine.lua
@@ -7,14 +7,14 @@ local lualine_nightfly = require("lualine.themes.nightfly")
 
 local new_colors = {
     blue = "#65D1FF",
-    gree = "#3EFFDC",
+    green = "#3EFFDC",
     violet = "#FF61EF",
     yellow = "#FFDA7B",
     black = "#000000",
 }
 
 lualine_nightfly.normal.a.bg = new_colors.blue
-lualine_nightfly.insert.a.bg = new_colors.gree
+lualine_nightfly.insert.a.bg = new_colors.green
 lualine_nightfly.visual.a.bg = new_colors.violet
 lualine_nightfly.command = {
     a = {


### PR DESCRIPTION
## Summary
- fix the color key name in lualine config
- correct `hint_sign` option in lspsaga setup

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_683f3b1f66208328992bf6f4fe7fd770