### PR TITLE
refactor(lsp): use notify for formatter debug

### DIFF
--- a/lua/pwalleni/plugins/lsp/none-ls.lua
+++ b/lua/pwalleni/plugins/lsp/none-ls.lua
@@ -33,10 +33,10 @@ null_ls.setup({
 		diagnostics.markdownlint,
 	},
 	on_attach = function(current_client, bufnr)
-		-- diagnostic debug
-		print("Formatter client name: ", current_client.name)
+                -- diagnostic debug
+                vim.notify("Formatter client name: " .. current_client.name, vim.log.levels.DEBUG)
 
-		vim.api.nvim_buf_set_option(bufnr, "formatexpr", "")
+                vim.api.nvim_buf_set_option(bufnr, "formatexpr", "")
 
 		if current_client.supports_method("textDocument/formatting") then
 			vim.api.nvim_clear_autocmds({ group = augroup, buffer = bufnr })


### PR DESCRIPTION
## Summary
- replace print with `vim.notify` at DEBUG level for formatter client logging

## Testing
- `luac -p lua/pwalleni/plugins/lsp/none-ls.lua`
- `nvim --headless +"lua dofile('lua/pwalleni/plugins/lsp/none-ls.lua')" +qa`


------
https://chatgpt.com/codex/tasks/task_e_688fa35cfb7c8328be1f44688beeaa3c